### PR TITLE
Allow to read Tor auth cookie

### DIFF
--- a/org.bitcoincore.bitcoin-qt.json
+++ b/org.bitcoincore.bitcoin-qt.json
@@ -15,7 +15,10 @@
     /* IPC access. */
     "--share=ipc",
     /* Network acess. */
-    "--share=network"
+    "--share=network",
+    /* Tor auth cookie */
+    "--filesystem=/run/tor/control.authcookie:ro",
+    "--filesystem=/var/run/tor/control.authcookie:ro"
   ],
   "modules": [
     {


### PR DESCRIPTION
Bitcoin can connect to system Tor and listen on onion address, but it needs to read authcookie file for that.