### PR TITLE
remove arm

### DIFF
--- a/org.bitcoincore.bitcoin-qt.json
+++ b/org.bitcoincore.bitcoin-qt.json
@@ -39,12 +39,6 @@
         },
         {
           "type": "archive",
-          "only-arches": ["arm"],
-          "url": "https://bitcoincore.org/bin/bitcoin-core-22.0/bitcoin-22.0-arm-linux-gnueabihf.tar.gz",
-          "sha256": "https://bitcoincore.org/bin/bitcoin-core-22.0/bitcoin-22.0-arm-linux-gnueabihf.tar.gz"
-        },
-        {
-          "type": "archive",
           "only-arches": ["aarch64"],
           "url": "https://bitcoincore.org/bin/bitcoin-core-22.0/bitcoin-22.0-aarch64-linux-gnu.tar.gz",
           "sha256": "ac718fed08570a81b3587587872ad85a25173afa5f9fbbd0c03ba4d1714cfa3e"


### PR DESCRIPTION
`arm` isn't used a lot, according to https://klausenbusk.github.io/flathub-stats/#ref=org.bitcoincore.bitcoin-qt&interval=infinity&downloadType=installs%2Bupdates not at all?

So remove the unused arch.