### PR TITLE
Remove faulty/redundant Tor authcookie fs perm

### DIFF
--- a/org.bitcoincore.bitcoin-qt.json
+++ b/org.bitcoincore.bitcoin-qt.json
@@ -10,8 +10,7 @@
         "--device=dri",
         "--share=ipc",
         "--share=network",
-        "--filesystem=/run/tor/control.authcookie:ro",
-        "--filesystem=/var/run/tor/control.authcookie:ro"
+        "--filesystem=/run/tor/control.authcookie:ro"
     ],
     "modules": [
         {


### PR DESCRIPTION
As I described [here](https://github.com/flathub/org.bitcoincore.bitcoin-qt/issues/17#issuecomment-1828300193), `/var/run/tor/control.authcookie` is not only redundant, but actually harmful.

---

Fixes: https://github.com/flathub/org.bitcoincore.bitcoin-qt/issues/17
See: https://github.com/flathub/org.bitcoincore.bitcoin-qt/issues/17#issuecomment-1828300193
See: https://github.com/flathub/org.bitcoincore.bitcoin-qt/issues/17#issuecomment-1828510261
See: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html