### PR TITLE
Improve Metainfo

### DIFF
--- a/org.bitcoincore.bitcoin-qt.metainfo.xml
+++ b/org.bitcoincore.bitcoin-qt.metainfo.xml
@@ -24,7 +24,7 @@
     </p>
   </description>
   <screenshots>
-    <screenshot>
+    <screenshot type="default">
       <image type="source">
         https://user-images.githubusercontent.com/6399679/62743657-2fc28b80-ba11-11e9-9bbf-d3ad0d17abb0.png
       </image>

--- a/org.bitcoincore.bitcoin-qt.metainfo.xml
+++ b/org.bitcoincore.bitcoin-qt.metainfo.xml
@@ -49,5 +49,8 @@
   </releases>
   <content_rating type="oars-1.1"/>
   <developer_name>Bitcoin Core</developer_name>
+  <developer id="org.bitcoincore">
+    <name>Bitcoin Core</name>
+  </developer>
 
 </component>


### PR DESCRIPTION
Flathub switched to appstreamcli for metainfo validation, passing this check is needed to push new updates. After running the test locally:

```
flatpak run --command=flatpak-builder-lint org.flatpak.Builder appstream *metainfo*
I: org.bitcoincore.bitcoin-qt:51: developer-name-tag-deprecated
   The toplevel `developer_name` element is deprecated. Please use the `name` element in a
   `developer` block instead.

✔ Validation was successful: infos: 1, pedantic: 1
```

Note that we do not want to remove the deprecated `developer_name` field as many frontends have not migrated to `developer` yet.