### PR TITLE
x-data-checker: Set x86 source as main source

### DIFF
--- a/org.bitcoincore.bitcoin-qt.json
+++ b/org.bitcoincore.bitcoin-qt.json
@@ -37,6 +37,7 @@
                         "type": "html",
                         "url": "https://bitcoincore.org/en/releasesrss.xml",
                         "version-pattern": "<title>Bitcoin Core ([\\d\\.]+)</title>",
+                        "is-main-source": true,
                         "url-template": "https://bitcoincore.org/bin/bitcoin-core-$version/bitcoin-$version-x86_64-linux-gnu.tar.gz"
                     }
                 },


### PR DESCRIPTION
@bbhtt Hi, is this what you meant at https://github.com/flathub/org.bitcoincore.bitcoin-qt/pull/44#issuecomment-2174691693 ?