### PR TITLE
Update to v30.0

### DIFF
--- a/org.bitcoincore.bitcoin-qt.json
+++ b/org.bitcoincore.bitcoin-qt.json
@@ -20,7 +20,7 @@
                 "install -m 0744 -D -t /app/bin/internal bin/bitcoind",
                 "install -m 0744 -D -t /app/bin/internal bin/bitcoin-qt",
                 "install -m 0744 -D -t /app/bin/internal bin/bitcoin-cli",
-                "install -m 0744 -D -t /app/bin/internal bin/test_bitcoin"
+                "install -m 0744 -D -t /app/bin/internal libexec/test_bitcoin"
             ],
             "post-install": [
                 "/app/bin/internal/test_bitcoin"
@@ -31,8 +31,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://bitcoincore.org/bin/bitcoin-core-29.1/bitcoin-29.1-x86_64-linux-gnu.tar.gz",
-                    "sha256": "2dddeaa8c0626ec446b6f21b64c0f3565a1e7e67ff0b586d25043cbd686c9455",
+                    "url": "https://bitcoincore.org/bin/bitcoin-core-30.0/bitcoin-30.0-x86_64-linux-gnu.tar.gz",
+                    "sha256": "00964ae375084113b1162f2f493b9372421608af23539766e315a3cb0ee54248",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://bitcoincore.org/en/releasesrss.xml",
@@ -46,8 +46,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://bitcoincore.org/bin/bitcoin-core-29.1/bitcoin-29.1-aarch64-linux-gnu.tar.gz",
-                    "sha256": "d6be913e1abc5effe57f50630b4bff2f89b38c092182c47f1fcde0ae12afc71c",
+                    "url": "https://bitcoincore.org/bin/bitcoin-core-30.0/bitcoin-30.0-aarch64-linux-gnu.tar.gz",
+                    "sha256": "785f49061ae65fcf31b8323803bbaa284569dc65e7aba68229e2da222a449635",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://bitcoincore.org/en/releasesrss.xml",

--- a/org.bitcoincore.bitcoin-qt.metainfo.xml
+++ b/org.bitcoincore.bitcoin-qt.metainfo.xml
@@ -31,8 +31,11 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="29.1" date="2025-09-04">
+    <release version="30.0" date="2025-10-11">
       <description></description>
+    </release>
+    <release version="29.1" date="2025-09-04">
+      <description/>
     </release>
     <release version="29.0" date="2025-04-14">
       <description/>


### PR DESCRIPTION
Update to v30.0, with an additional change to deal with test_bitcoin moving to libexec.